### PR TITLE
work without  require

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
   Exclude:
     - '.git/**/*'
     - 'vendor/**/*' # where github action stores cached bundle
-    - 'spec/abq/**/*'
+    - 'spec/fixture_specs/**/*'
 
 RSpec/DescribedClass:
   EnforcedStyle: explicit

--- a/lib/rspec/abq.rb
+++ b/lib/rspec/abq.rb
@@ -82,7 +82,7 @@ module RSpec
         RSpec.world.wants_to_quit = true # ask rspec to exit
         RSpec.configuration.error_exit_code = 0 # exit without error
         RSpec.world.non_example_failure = true # exit has nothing to do with tests
-        return
+        return true
       end
 
       # after the manfiest has been sent to the worker, the rspec process will quit and the workers will each start a
@@ -107,6 +107,7 @@ module RSpec
         # deterministic seed to all workers.
         fetch_next_example(message)
       end
+      nil
     end
 
     # Creates the socket to communicate with the worker and sends the worker the protocol

--- a/lib/rspec/abq/extensions.rb
+++ b/lib/rspec/abq/extensions.rb
@@ -2,7 +2,6 @@ module RSpec
   module Abq
     module Extensions
       def self.setup!
-        RSpec::Core::Configuration.prepend(Configuration)
         RSpec::Core::ExampleGroup.extend(ExampleGroup)
         RSpec::Core::Runner.prepend(Runner)
       end
@@ -92,24 +91,6 @@ module RSpec
         end
       end
 
-      module Configuration
-        def load_spec_files
-          # Where can we load our extensions
-          # - AFTER our gem has been loaded
-          # - AFTER the specs are loaded
-          # - BEFORE any of the state is touched (e.g. before the random seed has been used)
-          # Order of operations:
-          # Runner#run
-          # --> Runner#setup
-          # ----> Runner#configure
-          # ------> Abq.setup!
-          # --------> spec/spec_helper.rb
-          # ----> Configuration#load_spec_files <- maybe here?
-          # --> World#ordered_example_groups
-          super.tap { RSpec::Abq.setup_after_specs_loaded! }
-        end
-      end
-
       module Runner
         # Runs the provided example groups.
         #
@@ -118,6 +99,9 @@ module RSpec
         #   or the configured failure exit code (1 by default) if specs
         #   failed.
         def run_specs(example_groups)
+          should_quit = RSpec::Abq.setup_after_specs_loaded!
+          return 0 if should_quit
+
           examples_count = @world.example_count(example_groups)
           examples_passed = @configuration.reporter.report(examples_count) do |reporter|
             @configuration.with_suite_hooks do

--- a/spec/features/load_order_spec.rb
+++ b/spec/features/load_order_spec.rb
@@ -1,0 +1,17 @@
+# rubocop:disable RSpec/ExampleLength
+RSpec.describe "load order spec", unless: RSpec::Abq.disable_tests_when_run_by_abq? do
+  it "runs when .rspec doesn't load the gem", :aggregate_failures do
+    host = "127.0.0.1"
+    server = TCPServer.new host, 0
+    abq_socket = "#{host}:#{server.addr[1]}"
+    ENV["ABQ_SOCKET"] = abq_socket
+    ENV["ABQ_GENERATE_MANIFEST"] = abq_socket
+
+    # -O loads a specific .rspec file, in this case, ignoring .rspec which requires spec/helper
+    `bundle exec rspec -O /dev/null ./spec/fixture_specs/one_specs.rb`
+
+    expect($?).to be_success
+  end
+end
+
+# rubocop:enable RSpec/ExampleLength

--- a/spec/features/manifest_spec.rb
+++ b/spec/features/manifest_spec.rb
@@ -1,5 +1,3 @@
-require "json"
-
 # rubocop:disable RSpec/ExampleLength
 RSpec.describe "manifest generation", unless: RSpec::Abq.disable_tests_when_run_by_abq? do
   host = "127.0.0.1"

--- a/spec/fixture_specs/one_specs.rb
+++ b/spec/fixture_specs/one_specs.rb
@@ -1,3 +1,4 @@
+require 'spec_helper'
 # called `_specs.rb` to avoid it being called automatically
 # used by integration/abq_spec.rb
 RSpec.describe 'group 1' do


### PR DESCRIPTION
fixes failures in captain

this gem was expecting there to be a 
`.rspec` file that loaded `spec_helper.rb` (which would then load the gem) but in captain, we only load our `spec_helper` from within the tests, so the gem isn't loaded until later.