### PR TITLE
abq changed its output, this fixes our integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
         run: |
           set +e
           echo "run tests"
-          abq test --reporter dot --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" -- bundle exec rspec --pattern 'spec/fixture_specs/*_specs.rb' |
+          abq test --reporter dot --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" -- bin/rspec_without_output_for_abq.sh |
             tee $tty |
             head -n -1 |
             tail -n +2 > test-outputs/rspec-${{matrix.gemfile}}.txt

--- a/bin/generate-abq-test-output.rb
+++ b/bin/generate-abq-test-output.rb
@@ -3,7 +3,7 @@
 Dir['gemfiles/*.gemfile'].map do |gemfile|
   Thread.new do
     ENV['BUNDLE_GEMFILE'] = gemfile
-    output = `abq test --reporter dot -- bundle exec rspec --pattern 'spec/fixture_specs/*_specs.rb'`
+    output = `abq test --reporter dot -- bin/rspec_without_output_for_abq.sh`
     puts "#{gemfile}\n#{output}"
     rspec_version = File.basename(gemfile).split(".gemfile").first
     without_last_line = output.lines[0...-1].join

--- a/bin/rspec_without_output_for_abq.sh
+++ b/bin/rspec_without_output_for_abq.sh
@@ -1,0 +1,3 @@
+#! /bin/bash
+
+bundle exec rspec --pattern 'spec/fixture_specs/*_specs.rb' >/dev/null


### PR DESCRIPTION
abq prints way more stdout from workers, which makes the output of `abq test` much less consistent