### PR TITLE
prepare release v1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-abq (0.2.3)
+    rspec-abq (1.0.0)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -92,4 +92,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.3.24
+   2.3.7

--- a/bin/release_gem.rb
+++ b/bin/release_gem.rb
@@ -80,9 +80,9 @@ if version_to_release == latest_released_version
   when "1"
     ["patch", [major, minor, patch + 1].join(".")]
   when "2"
-    ["minor", [major, minor + 1, patch].join(".")]
+    ["minor", [major, minor + 1, 0].join(".")]
   when "3"
-    ["major", [major + 1, minor, patch + 1].join(".")]
+    ["major", [major + 1, 0, 0].join(".")]
   end
 
   if current_branch == "main"

--- a/gemfiles/rspec-3.10.gemfile.lock
+++ b/gemfiles/rspec-3.10.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-abq (0.2.3)
+    rspec-abq (1.0.0)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-abq!
 
 BUNDLED WITH
-   2.3.24
+   2.3.7

--- a/gemfiles/rspec-3.11.gemfile.lock
+++ b/gemfiles/rspec-3.11.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-abq (0.2.3)
+    rspec-abq (1.0.0)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-abq!
 
 BUNDLED WITH
-   2.3.24
+   2.3.7

--- a/gemfiles/rspec-3.12.gemfile.lock
+++ b/gemfiles/rspec-3.12.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-abq (0.2.3)
+    rspec-abq (1.0.0)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-abq!
 
 BUNDLED WITH
-   2.3.24
+   2.3.7

--- a/gemfiles/rspec-3.5.gemfile.lock
+++ b/gemfiles/rspec-3.5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-abq (0.2.3)
+    rspec-abq (1.0.0)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-abq!
 
 BUNDLED WITH
-   2.3.24
+   2.3.7

--- a/gemfiles/rspec-3.6.gemfile.lock
+++ b/gemfiles/rspec-3.6.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-abq (0.2.3)
+    rspec-abq (1.0.0)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-abq!
 
 BUNDLED WITH
-   2.3.24
+   2.3.7

--- a/gemfiles/rspec-3.7.gemfile.lock
+++ b/gemfiles/rspec-3.7.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-abq (0.2.3)
+    rspec-abq (1.0.0)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-abq!
 
 BUNDLED WITH
-   2.3.24
+   2.3.7

--- a/gemfiles/rspec-3.8.gemfile.lock
+++ b/gemfiles/rspec-3.8.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-abq (0.2.3)
+    rspec-abq (1.0.0)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-abq!
 
 BUNDLED WITH
-   2.3.24
+   2.3.7

--- a/gemfiles/rspec-3.9.gemfile.lock
+++ b/gemfiles/rspec-3.9.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    rspec-abq (0.2.3)
+    rspec-abq (1.0.0)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -31,4 +31,4 @@ DEPENDENCIES
   rspec-abq!
 
 BUNDLED WITH
-   2.3.24
+   2.3.7

--- a/lib/rspec/abq/version.rb
+++ b/lib/rspec/abq/version.rb
@@ -1,6 +1,6 @@
 module RSpec
   module Abq
     # current version!
-    VERSION = "0.2.3"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
- Bump rspec-abq to 1.0.0
- fix displayed version numbers in release gem
