### PR TITLE
Print a warning if ending the test run without being on the end marker

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,6 +74,7 @@ GEM
       webrick (~> 1.7.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/lib/rspec/abq/extensions.rb
+++ b/lib/rspec/abq/extensions.rb
@@ -125,7 +125,7 @@ module RSpec
             end
           end
 
-          if Abq.target_test_case == Abq.end_marker
+          if Abq.target_test_case == Abq::TestCase.end_marker
             exit_code(examples_passed)
           else
             warn "Hit end of test run without being on end marker. Target test case is #{Abq.target_test_case.inspect}"

--- a/lib/rspec/abq/extensions.rb
+++ b/lib/rspec/abq/extensions.rb
@@ -125,7 +125,12 @@ module RSpec
             end
           end
 
-          exit_code(examples_passed)
+          if Abq.target_test_case == Abq.end_marker
+            exit_code(examples_passed)
+          else
+            warn "Hit end of test run without being on end marker. Target test case is #{Abq.target_test_case.inspect}"
+            exit_code(false)
+          end
         end
 
         private


### PR DESCRIPTION
To help debug

> Ayaz Hafiz
  [21 minutes ago](https://rwxhq.slack.com/archives/C048MJEA406/p1669128241877429?thread_ts=1669124825.331169&cid=C048MJEA406)
I think it's a red herring - what might be happening is that we pass down a test ID that rspec-abq can't find (or thinks should be skipped, or is out of order) and rspec-abq hits the end of the list, and exits. We should probably add a guardrail at the end of the rspec test list to make sure it doesn't exit cleanly like this if there is a pending abq test