### PR TITLE
worker can fail 2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,6 @@ jobs:
         with:
           access-token: ${{ secrets.RWX_ACCESS_TOKEN }}
       - name: start abq work
-        continue-on-error: true
         run: abq work -n cpu-cores --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}"
         env:
           ABQ_LOG: ${{ runner.debug && 'debug' || 'info' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,7 +139,7 @@ jobs:
         run: |
           set +e
           echo "run tests"
-          output=$(abq test --reporter dot --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" -- bin/rspec_without_output_for_abq.sh)
+          output="$(abq test --reporter dot --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" -- bin/rspec_without_output_for_abq.sh)"
           echo $output
           echo $output |
             head -n -1 |
@@ -219,7 +219,7 @@ jobs:
         # abq work _should_ fail because we have failing tests, but we want to ensure it only has a single line of output
         run: |
           set +e
-          output=$(abq work -n cpu-cores --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" 2>&1)
+          output="$(abq work -n cpu-cores --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" 2>&1)"
           print $output
           lines=print $output | wc -l
           echo "num lines"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,8 +136,9 @@ jobs:
         run: |
           set +e
           echo "run tests"
-          abq test --reporter dot --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" -- bin/rspec_without_output_for_abq.sh |
-            tee $tty |
+          output=$(abq test --reporter dot --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" -- bin/rspec_without_output_for_abq.sh)
+          echo $output
+          echo $output |
             head -n -1 |
             tail -n +2 > test-outputs/rspec-${{matrix.gemfile}}.txt
           echo "**git diff**"
@@ -210,7 +211,14 @@ jobs:
           access-token: ${{ secrets.RWX_ACCESS_TOKEN }}
       - name: start abq work
         # abq work _should_ fail because we have failing tests, but we want to ensure it only has a single line of output
-        run: abq work -n cpu-cores --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" 2>&1 | wc -l | xargs test 1 =
+        run: |
+          set +e
+          output=$(abq work -n cpu-cores --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" 2>&1)
+          print $output
+          lines=print $output | wc -l
+          echo "num lines"
+          echo $lines
+          test "1" = "$lines"
         env:
           ABQ_LOG: ${{ runner.debug && 'debug' || 'info' }}
           ABQ_API_KEY: ${{ secrets.RWX_ACCESS_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,7 +174,7 @@ jobs:
             echo "Shards failed"
             exit 1
           fi
-  abq-work:
+  abq-work-matrix:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     strategy:
@@ -213,6 +213,33 @@ jobs:
         env:
           ABQ_LOG: ${{ runner.debug && 'debug' || 'info' }}
           ABQ_API_KEY: ${{ secrets.RWX_ACCESS_TOKEN }}
+  abq-work-after-matrix: # strategy borrowed from https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+    needs: abq-work-matrix # run after shards
+    runs-on: ubuntu-latest
+    if: success() # only run when matrix passed
+    # store success output flag for ci job
+    outputs:
+      success: ${{ steps.setoutput.outputs.success }}
+    steps:
+      - id: setoutput
+        run: echo "::set-output name=success::true"
+  abq-work:
+    runs-on: ubuntu-latest
+    if: always() # always run, so we never skip the check
+    needs: abq-work-after-matrix
+    steps:
+      # pass step only when output of previous after-shards job is set
+      # in case at least one of the shard fails, after-shards is skipped
+      # and the output will not be set, which will then cause the ci job to fail
+      - run: |
+          passed="${{ needs.abq-work-after-matrix.outputs.success }}"
+          if [[ $passed == "true" ]]; then
+            echo "Shards passed"
+            exit 0
+          else
+            echo "Shards failed"
+            exit 1
+          fi
   yard:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,10 @@ jobs:
             ]
           job-matrix: ${{ toJSON(matrix) }}
           captain-token: ${{ secrets.RWX_ACCESS_TOKEN }}
-  rspec-after-matrix: # strategy borrowed from https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+
+  # strategy borrowed from https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+  # this is used to summarize the matrix results into a single job (abq-work) that can be used as a required check
+  rspec-github-workflow-wrapup-helper:
     needs: rspec-matrix # run after shards
     runs-on: ubuntu-latest
     if: success() # only run when matrix passed
@@ -85,13 +88,13 @@ jobs:
   rspec:
     runs-on: ubuntu-latest
     if: always() # always run, so we never skip the check
-    needs: rspec-after-matrix
+    needs: rspec-github-workflow-wrapup-helper
     steps:
       # pass step only when output of previous after-shards job is set
       # in case at least one of the shard fails, after-shards is skipped
       # and the output will not be set, which will then cause the ci job to fail
       - run: |
-          passed="${{ needs.rspec-after-matrix.outputs.success }}"
+          passed="${{ needs.rspec-github-workflow-wrapup-helper.outputs.success }}"
           if [[ $passed == "true" ]]; then
             echo "Shards passed"
             exit 0
@@ -148,7 +151,10 @@ jobs:
         env:
           ABQ_LOG: ${{ runner.debug && 'debug' || 'info' }}
           ABQ_API_KEY: ${{ secrets.RWX_ACCESS_TOKEN }}
-  abq-test-after-matrix: # strategy borrowed from https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+
+  # strategy borrowed from https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+  # this is used to summarize the matrix results into a single job (abq-work) that can be used as a required check
+  abq-test-github-workflow-wrapup-helper:
     needs: abq-test-matrix # run after shards
     runs-on: ubuntu-latest
     if: success() # only run when matrix passed
@@ -161,13 +167,13 @@ jobs:
   abq-test:
     runs-on: ubuntu-latest
     if: always() # always run, so we never skip the check
-    needs: abq-test-after-matrix
+    needs: abq-test-github-workflow-wrapup-helper
     steps:
       # pass step only when output of previous after-shards job is set
       # in case at least one of the shard fails, after-shards is skipped
       # and the output will not be set, which will then cause the ci job to fail
       - run: |
-          passed="${{ needs.abq-test-after-matrix.outputs.success }}"
+          passed="${{ needs.abq-test-github-workflow-wrapup-helper.outputs.success }}"
           if [[ $passed == "true" ]]; then
             echo "Shards passed"
             exit 0
@@ -222,7 +228,9 @@ jobs:
         env:
           ABQ_LOG: ${{ runner.debug && 'debug' || 'info' }}
           ABQ_API_KEY: ${{ secrets.RWX_ACCESS_TOKEN }}
-  abq-work-after-matrix: # strategy borrowed from https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+  # strategy borrowed from https://brunoscheufler.com/blog/2022-04-09-the-required-github-status-check-that-wasnt
+  # this is used to summarize the matrix results into a single job (abq-work) that can be used as a required check
+  abq-work-github-workflow-wrapup-helper:
     needs: abq-work-matrix # run after shards
     runs-on: ubuntu-latest
     if: success() # only run when matrix passed
@@ -235,13 +243,13 @@ jobs:
   abq-work:
     runs-on: ubuntu-latest
     if: always() # always run, so we never skip the check
-    needs: abq-work-after-matrix
+    needs: abq-work-github-workflow-wrapup-helper
     steps:
       # pass step only when output of previous after-shards job is set
       # in case at least one of the shard fails, after-shards is skipped
       # and the output will not be set, which will then cause the ci job to fail
       - run: |
-          passed="${{ needs.abq-work-after-matrix.outputs.success }}"
+          passed="${{ needs.abq-work-github-workflow-wrapup-helper.outputs.success }}"
           if [[ $passed == "true" ]]; then
             echo "Shards passed"
             exit 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,8 @@ jobs:
         with:
           access-token: ${{ secrets.RWX_ACCESS_TOKEN }}
       - name: start abq work
-        run: abq work -n cpu-cores --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}"
+        # abq work _should_ fail because we have failing tests, but we want to ensure it only has a single line of output
+        run: abq work -n cpu-cores --run-id "$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT-${{matrix.ruby}}-${{matrix.gemfile}}" 2>&1 | wc -l | xargs test 1 =
         env:
           ABQ_LOG: ${{ runner.debug && 'debug' || 'info' }}
           ABQ_API_KEY: ${{ secrets.RWX_ACCESS_TOKEN }}

--- a/lib/rspec/abq/extensions.rb
+++ b/lib/rspec/abq/extensions.rb
@@ -125,11 +125,15 @@ module RSpec
             end
           end
 
-          if Abq.target_test_case == Abq::TestCase.end_marker
+          if Abq.target_test_case != Abq::TestCase.end_marker
+            warn "Hit end of test run without being on end marker. Target test case is #{Abq.target_test_case.inspect}"
+            example_passed = false
+          end
+
+          if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new("3.10.0")
             exit_code(examples_passed)
           else
-            warn "Hit end of test run without being on end marker. Target test case is #{Abq.target_test_case.inspect}"
-            exit_code(false)
+            example_passed ? 0 : @configuration.failure_exit_code
           end
         end
 


### PR DESCRIPTION
- worker fails
- summarize worker success
- support older rspec versions properly
- test that abq work has a single line of output
- debug info
- rename after-matrix jobs and explain more why they're there
- quote output to prevent splitting
