### PR TITLE
Support abq `NativeRunnerSpawned` messages

### DIFF
--- a/gemfiles/rspec-3.10.gemfile.lock
+++ b/gemfiles/rspec-3.10.gemfile.lock
@@ -28,6 +28,7 @@ GEM
     rspec-support (3.10.3)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/gemfiles/rspec-3.11.gemfile.lock
+++ b/gemfiles/rspec-3.11.gemfile.lock
@@ -28,6 +28,7 @@ GEM
     rspec-support (3.11.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/gemfiles/rspec-3.12.gemfile.lock
+++ b/gemfiles/rspec-3.12.gemfile.lock
@@ -28,6 +28,7 @@ GEM
     rspec-support (3.12.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/gemfiles/rspec-3.5.gemfile.lock
+++ b/gemfiles/rspec-3.5.gemfile.lock
@@ -28,6 +28,7 @@ GEM
     rspec-support (3.5.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/gemfiles/rspec-3.6.gemfile.lock
+++ b/gemfiles/rspec-3.6.gemfile.lock
@@ -28,6 +28,7 @@ GEM
     rspec-support (3.6.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/gemfiles/rspec-3.7.gemfile.lock
+++ b/gemfiles/rspec-3.7.gemfile.lock
@@ -28,6 +28,7 @@ GEM
     rspec-support (3.7.1)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/gemfiles/rspec-3.8.gemfile.lock
+++ b/gemfiles/rspec-3.8.gemfile.lock
@@ -28,6 +28,7 @@ GEM
     rspec-support (3.8.3)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/gemfiles/rspec-3.9.gemfile.lock
+++ b/gemfiles/rspec-3.9.gemfile.lock
@@ -28,6 +28,7 @@ GEM
     rspec-support (3.9.4)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 

--- a/lib/rspec/abq.rb
+++ b/lib/rspec/abq.rb
@@ -41,7 +41,7 @@ module RSpec
     NATIVE_RUNNER_SPECIFICATION = {
       type: "abq_native_runner_specification",
       name: "rspec-abq",
-      version: RSpec::Abq::VERSION,
+      version: RSpec::Abq::VERSION
     }
 
     # The [rpsec-abq spawned message](https://www.notion.so/rwx/ABQ-Worker-Native-Test-Runner-IPC-Interface-0959f5a9144741d798ac122566a3d887#8587ee4fd01e41ec880dcbe212562172).
@@ -50,7 +50,7 @@ module RSpec
     NATIVE_RUNNER_SPAWNED_MESSAGE = {
       type: "abq_native_runner_spawned",
       protocol_version: PROTOCOL_VERSION,
-      runner_specification: NATIVE_RUNNER_SPECIFICATION,
+      runner_specification: NATIVE_RUNNER_SPECIFICATION
     }
 
     # The [ABQ initialization success

--- a/lib/rspec/abq.rb
+++ b/lib/rspec/abq.rb
@@ -29,12 +29,28 @@ module RSpec
     ABQ_RSPEC_PID = "ABQ_RSPEC_PID"
 
     # The [ABQ protocol version message](https://www.notion.so/rwx/ABQ-Worker-Native-Test-Runner-IPC-Interface-0959f5a9144741d798ac122566a3d887#8587ee4fd01e41ec880dcbe212562172).
-    # Must be sent to ABQ_SOCKET on startup.
     # @!visibility private
-    PROTOCOL_VERSION_MESSAGE = {
+    PROTOCOL_VERSION = {
       type: "abq_protocol_version",
       major: 0,
       minor: 1
+    }
+
+    # The [rspec-abq specification](https://www.notion.so/rwx/ABQ-Worker-Native-Test-Runner-IPC-Interface-0959f5a9144741d798ac122566a3d887#8587ee4fd01e41ec880dcbe212562172).
+    # @!visibility private
+    NATIVE_RUNNER_SPECIFICATION = {
+      type: "abq_native_runner_specification",
+      name: "rspec-abq",
+      version: RSpec::Abq::VERSION,
+    }
+
+    # The [rpsec-abq spawned message](https://www.notion.so/rwx/ABQ-Worker-Native-Test-Runner-IPC-Interface-0959f5a9144741d798ac122566a3d887#8587ee4fd01e41ec880dcbe212562172).
+    # Must be sent to ABQ_SOCKET on startup.
+    # @!visibility private
+    NATIVE_RUNNER_SPAWNED_MESSAGE = {
+      type: "abq_native_runner_spawned",
+      protocol_version: PROTOCOL_VERSION,
+      runner_specification: NATIVE_RUNNER_SPECIFICATION,
     }
 
     # The [ABQ initialization success
@@ -127,7 +143,7 @@ module RSpec
         # Messages sent to/received from the ABQ worker should be done so ASAP.
         # Since we're on a local network, we don't care about packet reduction here.
         socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
-        protocol_write(PROTOCOL_VERSION_MESSAGE, socket)
+        protocol_write(NATIVE_RUNNER_SPAWNED_MESSAGE, socket)
       end
     end
 

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -22,6 +22,7 @@ RSpec.describe "abq test" do
   def sanitize_test_output(output)
     output
       .gsub(/completed in \d+ ms/, "completed in 0 ms") # timing is unstable
+      .gsub(/^Finished in .* seconds .*$/, "Finished in 0 seconds") # timing is unstable
       .gsub(/^Starting test run with ID.+/, "Starting test run with ID not-the-real-test-run-id") # and so is the test run id
   end
 
@@ -33,6 +34,7 @@ RSpec.describe "abq test" do
   def sanitize_worker_error(output)
     output
       .gsub(/Worker started with id .+/, "Worker started with id not-the-real-test-run-id") # timing is unstable
+      .gsub(/^.*lib\/rspec\/core.*: warning.*$/, "") # strip file path warnings
   end
 
   context "with queue and worker" do

--- a/spec/features/manifest_spec.rb
+++ b/spec/features/manifest_spec.rb
@@ -3,6 +3,19 @@ require "spec_helper"
 RSpec.describe "manifest generation", unless: RSpec::Abq.disable_tests_when_run_by_abq? do
   host = "127.0.0.1"
   ordered_manifest = {"manifest" => {"init_meta" => {"ordering" => "defined"}, "members" => [{"members" => [{"id" => "./spec/fixture_specs/one_specs.rb[1:1]", "meta" => {}, "tags" => %w[bar foo], "type" => "test"}, {"id" => "./spec/fixture_specs/one_specs.rb[1:2]", "meta" => {"bar" => 5}, "tags" => ["foo"], "type" => "test"}, {"members" => [{"id" => "./spec/fixture_specs/one_specs.rb[1:3:1]", "meta" => {"skip" => "Temporarily skipped with xit"}, "tags" => ["foo"], "type" => "test"}, {"id" => "./spec/fixture_specs/one_specs.rb[1:3:2]", "meta" => {}, "tags" => ["foo"], "type" => "test"}], "meta" => {}, "name" => "./spec/fixture_specs/one_specs.rb[1:3]", "tags" => ["foo"], "type" => "group"}], "meta" => {}, "name" => "./spec/fixture_specs/one_specs.rb[1]", "tags" => [], "type" => "group"}, {"members" => [{"id" => "./spec/fixture_specs/two_specs.rb[1:2]", "meta" => {}, "tags" => [], "type" => "test"}, {"members" => [{"id" => "./spec/fixture_specs/two_specs.rb[1:3:1]", "meta" => {"skip" => "Temporarily skipped with xdescribe"}, "tags" => [], "type" => "test"}, {"id" => "./spec/fixture_specs/two_specs.rb[1:3:2]", "meta" => {"skip" => "Temporarily skipped with xdescribe"}, "tags" => [], "type" => "test"}], "meta" => {"skip" => "Temporarily skipped with xdescribe"}, "name" => "./spec/fixture_specs/two_specs.rb[1:3]", "tags" => [], "type" => "group"}], "meta" => {}, "name" => "./spec/fixture_specs/two_specs.rb[1]", "tags" => [], "type" => "group"}]}}
+  expected_spawn_msg = {
+    "type" => "abq_native_runner_spawned",
+    "protocol_version" => {
+      "type" => "abq_protocol_version",
+      "major" => 0,
+      "minor" => 1
+    },
+    "runner_specification" => {
+      "type" => "abq_native_runner_specification",
+      "name" => "rspec-abq",
+      "version" => "1.0.1"
+    }
+  }
 
   it "generates manifest", :aggregate_failures do
     server = TCPServer.new host, 0
@@ -12,7 +25,7 @@ RSpec.describe "manifest generation", unless: RSpec::Abq.disable_tests_when_run_
     end
 
     sock = server.accept
-    expect(RSpec::Abq.protocol_read(sock)).to eq({"major" => 0, "minor" => 1, "type" => "abq_protocol_version"})
+    expect(RSpec::Abq.protocol_read(sock)).to eq(expected_spawn_msg)
     manifest = RSpec::Abq.protocol_read(sock)
     manifest["manifest"]["init_meta"].delete("seed")
     expect(manifest).to match(ordered_manifest)
@@ -27,7 +40,7 @@ RSpec.describe "manifest generation", unless: RSpec::Abq.disable_tests_when_run_
     end
     sock = server.accept
 
-    expect(RSpec::Abq.protocol_read(sock)).to eq({"major" => 0, "minor" => 1, "type" => "abq_protocol_version"})
+    expect(RSpec::Abq.protocol_read(sock)).to eq(expected_spawn_msg)
     manifest = RSpec::Abq.protocol_read(sock)
     expect(manifest).not_to eq(ordered_manifest)
     expect(manifest["manifest"]["init_meta"]).to eq({"seed" => 2, "ordering" => "random"})

--- a/spec/rspec/abq_spec.rb
+++ b/spec/rspec/abq_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe RSpec::Abq do
           RSpec::Abq.socket
         }
         RSpec::Abq.protocol_write({"init_meta" => {"seed" => 4, "ordering_class" => "RSpec::Core::Ordering::Identity"}}, server_sock)
-        expect(RSpec::Abq.protocol_read(server_sock)).to(eq(stringify_keys(RSpec::Abq::PROTOCOL_VERSION_MESSAGE)))
+        expect(RSpec::Abq.protocol_read(server_sock)).to(eq(stringify_keys(RSpec::Abq::NATIVE_RUNNER_SPAWNED_MESSAGE)))
       end
     end
   end

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.10.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.10.gemfile.txt
@@ -1,2 +1,5 @@
 Starting test run with ID not-the-real-test-run-id
 .SS
+
+Finished in 0 seconds
+3 tests, 0 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.11.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.11.gemfile.txt
@@ -1,2 +1,5 @@
 Starting test run with ID not-the-real-test-run-id
 .SS
+
+Finished in 0 seconds
+3 tests, 0 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.12.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.12.gemfile.txt
@@ -1,2 +1,5 @@
 Starting test run with ID not-the-real-test-run-id
 .SS
+
+Finished in 0 seconds
+3 tests, 0 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.5.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.5.gemfile.txt
@@ -1,2 +1,5 @@
 Starting test run with ID not-the-real-test-run-id
 .SS
+
+Finished in 0 seconds
+3 tests, 0 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.6.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.6.gemfile.txt
@@ -1,2 +1,5 @@
 Starting test run with ID not-the-real-test-run-id
 .SS
+
+Finished in 0 seconds
+3 tests, 0 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.7.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.7.gemfile.txt
@@ -1,2 +1,5 @@
 Starting test run with ID not-the-real-test-run-id
 .SS
+
+Finished in 0 seconds
+3 tests, 0 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.8.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.8.gemfile.txt
@@ -1,2 +1,5 @@
 Starting test run with ID not-the-real-test-run-id
 .SS
+
+Finished in 0 seconds
+3 tests, 0 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.9.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-test-stdout-rspec-3.9.gemfile.txt
@@ -1,2 +1,5 @@
 Starting test run with ID not-the-real-test-run-id
 .SS
+
+Finished in 0 seconds
+3 tests, 0 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-work-stderr-rspec-3.5.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-work-stderr-rspec-3.5.gemfile.txt
@@ -1,5 +1,5 @@
 Worker started with id not-the-real-test-run-id
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
+
+
+
+

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-work-stderr-rspec-3.6.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-work-stderr-rspec-3.6.gemfile.txt
@@ -1,5 +1,5 @@
 Worker started with id not-the-real-test-run-id
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
+
+
+
+

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-work-stderr-rspec-3.7.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:1]-work-stderr-rspec-3.7.gemfile.txt
@@ -1,5 +1,5 @@
 Worker started with id not-the-real-test-run-id
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
+
+
+
+

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.10.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.10.gemfile.txt
@@ -17,7 +17,7 @@ F.S..SS
        +false
      # ./spec/fixture_specs/one_specs.rb:6:in `block (2 levels) in <top (required)>'
      # ./lib/rspec/abq/extensions.rb:44:in `block (2 levels) in run_examples_with_abq'
-     # ./lib/rspec/abq.rb:205:in `send_test_result_and_advance'
+     # ./lib/rspec/abq.rb:221:in `send_test_result_and_advance'
      # ./lib/rspec/abq/extensions.rb:44:in `block in run_examples_with_abq'
      # ./lib/rspec/abq/extensions.rb:32:in `each'
      # ./lib/rspec/abq/extensions.rb:32:in `run_examples_with_abq'

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.10.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.10.gemfile.txt
@@ -29,3 +29,7 @@ F.S..SS
      # ./lib/rspec/abq/extensions.rb:118:in `run_specs'
 
 (completed in 0 ms)
+
+
+Finished in 0 seconds
+7 tests, 1 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.11.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.11.gemfile.txt
@@ -17,7 +17,7 @@ F.S..SS
        +false
      # ./spec/fixture_specs/one_specs.rb:6:in `block (2 levels) in <top (required)>'
      # ./lib/rspec/abq/extensions.rb:44:in `block (2 levels) in run_examples_with_abq'
-     # ./lib/rspec/abq.rb:205:in `send_test_result_and_advance'
+     # ./lib/rspec/abq.rb:221:in `send_test_result_and_advance'
      # ./lib/rspec/abq/extensions.rb:44:in `block in run_examples_with_abq'
      # ./lib/rspec/abq/extensions.rb:32:in `each'
      # ./lib/rspec/abq/extensions.rb:32:in `run_examples_with_abq'

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.11.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.11.gemfile.txt
@@ -29,3 +29,7 @@ F.S..SS
      # ./lib/rspec/abq/extensions.rb:118:in `run_specs'
 
 (completed in 0 ms)
+
+
+Finished in 0 seconds
+7 tests, 1 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.12.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.12.gemfile.txt
@@ -17,7 +17,7 @@ F.S..SS
        +false
      # ./spec/fixture_specs/one_specs.rb:6:in `block (2 levels) in <top (required)>'
      # ./lib/rspec/abq/extensions.rb:44:in `block (2 levels) in run_examples_with_abq'
-     # ./lib/rspec/abq.rb:205:in `send_test_result_and_advance'
+     # ./lib/rspec/abq.rb:221:in `send_test_result_and_advance'
      # ./lib/rspec/abq/extensions.rb:44:in `block in run_examples_with_abq'
      # ./lib/rspec/abq/extensions.rb:32:in `each'
      # ./lib/rspec/abq/extensions.rb:32:in `run_examples_with_abq'

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.12.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.12.gemfile.txt
@@ -29,3 +29,7 @@ F.S..SS
      # ./lib/rspec/abq/extensions.rb:118:in `run_specs'
 
 (completed in 0 ms)
+
+
+Finished in 0 seconds
+7 tests, 1 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.5.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.5.gemfile.txt
@@ -12,7 +12,7 @@ F.S..SS
        (compared using ==)
      # ./spec/fixture_specs/one_specs.rb:6:in `block (2 levels) in <top (required)>'
      # ./lib/rspec/abq/extensions.rb:44:in `block (2 levels) in run_examples_with_abq'
-     # ./lib/rspec/abq.rb:205:in `send_test_result_and_advance'
+     # ./lib/rspec/abq.rb:221:in `send_test_result_and_advance'
      # ./lib/rspec/abq/extensions.rb:44:in `block in run_examples_with_abq'
      # ./lib/rspec/abq/extensions.rb:32:in `each'
      # ./lib/rspec/abq/extensions.rb:32:in `run_examples_with_abq'

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.5.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.5.gemfile.txt
@@ -24,3 +24,7 @@ F.S..SS
      # ./lib/rspec/abq/extensions.rb:118:in `run_specs'
 
 (completed in 0 ms)
+
+
+Finished in 0 seconds
+7 tests, 1 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.6.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.6.gemfile.txt
@@ -12,7 +12,7 @@ F.S..SS
        (compared using ==)
      # ./spec/fixture_specs/one_specs.rb:6:in `block (2 levels) in <top (required)>'
      # ./lib/rspec/abq/extensions.rb:44:in `block (2 levels) in run_examples_with_abq'
-     # ./lib/rspec/abq.rb:205:in `send_test_result_and_advance'
+     # ./lib/rspec/abq.rb:221:in `send_test_result_and_advance'
      # ./lib/rspec/abq/extensions.rb:44:in `block in run_examples_with_abq'
      # ./lib/rspec/abq/extensions.rb:32:in `each'
      # ./lib/rspec/abq/extensions.rb:32:in `run_examples_with_abq'

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.6.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.6.gemfile.txt
@@ -24,3 +24,7 @@ F.S..SS
      # ./lib/rspec/abq/extensions.rb:118:in `run_specs'
 
 (completed in 0 ms)
+
+
+Finished in 0 seconds
+7 tests, 1 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.7.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.7.gemfile.txt
@@ -12,7 +12,7 @@ F.S..SS
        (compared using ==)
      # ./spec/fixture_specs/one_specs.rb:6:in `block (2 levels) in <top (required)>'
      # ./lib/rspec/abq/extensions.rb:44:in `block (2 levels) in run_examples_with_abq'
-     # ./lib/rspec/abq.rb:205:in `send_test_result_and_advance'
+     # ./lib/rspec/abq.rb:221:in `send_test_result_and_advance'
      # ./lib/rspec/abq/extensions.rb:44:in `block in run_examples_with_abq'
      # ./lib/rspec/abq/extensions.rb:32:in `each'
      # ./lib/rspec/abq/extensions.rb:32:in `run_examples_with_abq'

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.7.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.7.gemfile.txt
@@ -24,3 +24,7 @@ F.S..SS
      # ./lib/rspec/abq/extensions.rb:118:in `run_specs'
 
 (completed in 0 ms)
+
+
+Finished in 0 seconds
+7 tests, 1 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.8.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.8.gemfile.txt
@@ -17,7 +17,7 @@ F.S..SS
        +false
      # ./spec/fixture_specs/one_specs.rb:6:in `block (2 levels) in <top (required)>'
      # ./lib/rspec/abq/extensions.rb:44:in `block (2 levels) in run_examples_with_abq'
-     # ./lib/rspec/abq.rb:205:in `send_test_result_and_advance'
+     # ./lib/rspec/abq.rb:221:in `send_test_result_and_advance'
      # ./lib/rspec/abq/extensions.rb:44:in `block in run_examples_with_abq'
      # ./lib/rspec/abq/extensions.rb:32:in `each'
      # ./lib/rspec/abq/extensions.rb:32:in `run_examples_with_abq'

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.8.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.8.gemfile.txt
@@ -29,3 +29,7 @@ F.S..SS
      # ./lib/rspec/abq/extensions.rb:118:in `run_specs'
 
 (completed in 0 ms)
+
+
+Finished in 0 seconds
+7 tests, 1 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.9.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.9.gemfile.txt
@@ -17,7 +17,7 @@ F.S..SS
        +false
      # ./spec/fixture_specs/one_specs.rb:6:in `block (2 levels) in <top (required)>'
      # ./lib/rspec/abq/extensions.rb:44:in `block (2 levels) in run_examples_with_abq'
-     # ./lib/rspec/abq.rb:205:in `send_test_result_and_advance'
+     # ./lib/rspec/abq.rb:221:in `send_test_result_and_advance'
      # ./lib/rspec/abq/extensions.rb:44:in `block in run_examples_with_abq'
      # ./lib/rspec/abq/extensions.rb:32:in `each'
      # ./lib/rspec/abq/extensions.rb:32:in `run_examples_with_abq'

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.9.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-test-stdout-rspec-3.9.gemfile.txt
@@ -29,3 +29,7 @@ F.S..SS
      # ./lib/rspec/abq/extensions.rb:118:in `run_specs'
 
 (completed in 0 ms)
+
+
+Finished in 0 seconds
+7 tests, 1 failures

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-work-stderr-rspec-3.5.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-work-stderr-rspec-3.5.gemfile.txt
@@ -1,5 +1,5 @@
 Worker started with id not-the-real-test-run-id
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
+
+
+
+

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-work-stderr-rspec-3.6.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-work-stderr-rspec-3.6.gemfile.txt
@@ -1,5 +1,5 @@
 Worker started with id not-the-real-test-run-id
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.6.0/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
+
+
+
+

--- a/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-work-stderr-rspec-3.7.gemfile.txt
+++ b/spec/test-outputs/spec-features-integration_spec.rb[1:1:2]-work-stderr-rspec-3.7.gemfile.txt
@@ -1,5 +1,5 @@
 Worker started with id not-the-real-test-run-id
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
-/Users/michaelglass/Documents/work/rwx/rspec-abq/.gem/7c0f4604e2fa29a18e9d24821c285f7c/gems/rspec-core-3.7.1/lib/rspec/core/configuration_options.rb:171: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
+
+
+
+


### PR DESCRIPTION
Updates to support https://github.com/rwx-research/abq/issues/289 and https://github.com/rwx-research/abq/pull/317

The new protocol is documented at https://www.notion.so/rwx/ABQ-Worker-Native-Test-Runner-IPC-Interface-0959f5a9144741d798ac122566a3d887#8587ee4fd01e41ec880dcbe212562172