### PR TITLE
simpler exit strategy for rspec abq

### DIFF
--- a/lib/rspec/abq.rb
+++ b/lib/rspec/abq.rb
@@ -106,14 +106,6 @@ module RSpec
       # before abq can start workers, it asks for a manifest
       if !!ENV[ABQ_GENERATE_MANIFEST] # the abq worker will set this env var if it needs a manifest
         RSpec::Abq::Manifest.write_manifest(RSpec.world.ordered_example_groups, RSpec.configuration.seed, RSpec.configuration.ordering_registry)
-        # ... Maybe it's fine to just exit(0)
-        if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new("3.10.0")
-          RSpec.world.wants_to_quit = true # ask rspec to exit
-          RSpec.configuration.error_exit_code = 0
-          RSpec.world.non_example_failure = true # exit has nothing to do with tests
-        else
-          exit(0)
-        end
         return true
       end
 

--- a/spec/rspec/abq_spec.rb
+++ b/spec/rspec/abq_spec.rb
@@ -26,29 +26,11 @@ RSpec.describe RSpec::Abq do
       end
     end
 
-    if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new("3.10.0")
-      it "on newer rspec, if the env var is set, it writes the manifest and quits", :aggregate_failures do
-        expect(RSpec::Abq::Manifest).to receive(:write_manifest)
+    it "on newer rspec, if the env var is set, it writes the manifest and quits", :aggregate_failures do
+      expect(RSpec::Abq::Manifest).to receive(:write_manifest)
 
-        expect(RSpec.world).to receive(:wants_to_quit=).with(true)
-        expect(RSpec.configuration).to receive(:error_exit_code=).with(0)
-        expect(RSpec.world).to receive(:non_example_failure=).with(true)
-
-        EnvHelper.with_env(RSpec::Abq::ABQ_GENERATE_MANIFEST => "true") do
-          expect(RSpec::Abq.setup_after_specs_loaded!).to be true
-        end
-      end
-    else
-      it "on older rspec, if the env var is set, it writes the manifest and quits", :aggregate_failures do
-        expect(RSpec::Abq::Manifest).to receive(:write_manifest)
-
-        EnvHelper.with_env(RSpec::Abq::ABQ_GENERATE_MANIFEST => "true") do
-          expect {
-            expect(RSpec::Abq.setup_after_specs_loaded!).to be true
-          }.to raise_error(SystemExit) do |error|
-            expect(error.status).to eq(0)
-          end
-        end
+      EnvHelper.with_env(RSpec::Abq::ABQ_GENERATE_MANIFEST => "true") do
+        expect(RSpec::Abq.setup_after_specs_loaded!).to be true
       end
     end
 

--- a/spec/rspec/abq_spec.rb
+++ b/spec/rspec/abq_spec.rb
@@ -110,6 +110,6 @@ RSpec.describe RSpec::Abq do
       end
     end
 
-    # note: more manifest generation tests are in spec/features/integration_spec.rb
+    # note: more manifest generation tests are in spec/features/manifest_spec.rb
   end
 end

--- a/spec/rspec/abq_spec.rb
+++ b/spec/rspec/abq_spec.rb
@@ -26,10 +26,14 @@ RSpec.describe RSpec::Abq do
       end
     end
 
-    it "on newer rspec, if the env var is set, it writes the manifest and quits", :aggregate_failures do
-      expect(RSpec::Abq::Manifest).to receive(:write_manifest)
+    context 'with the ABQ_GENERATE_MANIFEST env var set to "true"' do
+      around { |example| EnvHelper.with_env(RSpec::Abq::ABQ_GENERATE_MANIFEST => "true") { example.run } }
 
-      EnvHelper.with_env(RSpec::Abq::ABQ_GENERATE_MANIFEST => "true") do
+      it "if the manifest env var is set, it writes the manifest and quits", :aggregate_failures do
+        expect(RSpec::Abq::Manifest).to receive(:write_manifest)
+        # manifest writing happens before the init message is sent from the worker to the native runner
+        expect(RSpec::Abq).not_to receive(:protocol_read)
+
         expect(RSpec::Abq.setup_after_specs_loaded!).to be true
       end
     end


### PR DESCRIPTION
tracing the thread from #56 (thanks @dan-manges)

this prevents us from calling `exit(0)` (or _explicitly_ quitting at all) when writing the manifest, instead pretending that there were no tests to run.