### PR TITLE
add test harness for capturing native runner exit code (and use it to fix a bug)

### DIFF
--- a/bin/echo_exit_code.rb
+++ b/bin/echo_exit_code.rb
@@ -1,7 +1,9 @@
 #!/usr/bin/env ruby
 
 # abq uses test results to determine whether to exit with 0 or 1.
-# this echos the exit code for comparing with in tests
+# abq (as far as I know?) ignores the native runner's exit code.
+#
+# this echos the native runner's exit code to ensure it's what we want in the test code.
 
 system(*ARGV)
 

--- a/bin/echo_exit_code.rb
+++ b/bin/echo_exit_code.rb
@@ -1,0 +1,8 @@
+#!/usr/bin/env ruby
+
+# abq uses test results to determine whether to exit with 0 or 1.
+# this echos the exit code for comparing with in tests
+
+system(*ARGV)
+
+puts "exit code: #{$?.exitstatus}"

--- a/lib/rspec/abq/extensions.rb
+++ b/lib/rspec/abq/extensions.rb
@@ -127,13 +127,13 @@ module RSpec
 
           if Abq.target_test_case != Abq::TestCase.end_marker
             warn "Hit end of test run without being on end marker. Target test case is #{Abq.target_test_case.inspect}"
-            example_passed = false
+            examples_passed = false
           end
 
           if Gem::Version.new(RSpec::Core::Version::STRING) >= Gem::Version.new("3.10.0")
             exit_code(examples_passed)
           else
-            example_passed ? 0 : @configuration.failure_exit_code
+            examples_passed ? 0 : @configuration.failure_exit_code
           end
         end
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.10.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec spec/fixture_specs/specs_with_syntax_errors.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.11.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec spec/fixture_specs/specs_with_syntax_errors.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.12.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec spec/fixture_specs/specs_with_syntax_errors.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.5.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec spec/fixture_specs/specs_with_syntax_errors.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:8]-test-stderr-rspec-3.9.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec spec/fixture_specs/specs_with_syntax_errors.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.10.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec --pattern spec/fixture_specs/**/*.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.11.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec --pattern spec/fixture_specs/**/*.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.12.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec --pattern spec/fixture_specs/**/*.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.5.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec --pattern spec/fixture_specs/**/*.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/spec-features-integration_spec.rb[1:1:9]-test-stderr-rspec-3.9.gemfile.snap
@@ -1,6 +1,5 @@
 Error: The command
 
-    bundle exec rspec --pattern spec/fixture_specs/**/*.rb
 
 failed to be run by all ABQ workers associating to this test run.
 

--- a/spec/fixture_specs/failing_specs.rb
+++ b/spec/fixture_specs/failing_specs.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative "../spec_helper"
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'a failing group' do

--- a/spec/fixture_specs/for_manifest/one_specs.rb
+++ b/spec/fixture_specs/for_manifest/one_specs.rb
@@ -1,4 +1,5 @@
-require 'spec_helper'
+require_relative "../../spec_helper"
+
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'group 1' do

--- a/spec/fixture_specs/for_manifest/two_specs.rb
+++ b/spec/fixture_specs/for_manifest/two_specs.rb
@@ -1,4 +1,6 @@
-# called `_specs.rb` to avoid it being called automatically
+require_relative "../../spec_helper"
+
+## called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'group 2' do
   it 'filtered out example 1', :if => false do end

--- a/spec/fixture_specs/pending_specs.rb
+++ b/spec/fixture_specs/pending_specs.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative "../spec_helper"
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'a pending group' do

--- a/spec/fixture_specs/raising_specs.rb
+++ b/spec/fixture_specs/raising_specs.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative "../spec_helper"
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'a raising group' do

--- a/spec/fixture_specs/specs_with_syntax_errors.rb
+++ b/spec/fixture_specs/specs_with_syntax_errors.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative "../spec_helper"
 # this file is named differently than all the other fixture_specs.rb so it doesn't get globbed with them
 # if it gets loaded, no specs run
 # used by feature specs

--- a/spec/fixture_specs/successful_specs.rb
+++ b/spec/fixture_specs/successful_specs.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require_relative "../spec_helper"
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'a successful group' do


### PR DESCRIPTION
@dan-manges caught a bug in rspec-abq that wasn't being surfaced because of how abq handles exit codes.

1. for rspec > 3.10 we weren't setting a failing exit code when rspec-abq was out of order with the tests coming from the worker (this happened, for instance, when random ordering wasn't working)

2. for rspec < 3.10, we were always returning a failing exit code even if tests were successful.

This tests for the bug and fixes it.