### PR TITLE
prefer using require directly

### DIFF
--- a/lib/rspec/abq.rb
+++ b/lib/rspec/abq.rb
@@ -2,12 +2,12 @@ require "set"
 require "rspec/core"
 require "socket"
 require "json"
-require_relative "abq/extensions"
-require_relative "abq/manifest"
-require_relative "abq/ordering"
-require_relative "abq/reporter"
-require_relative "abq/test_case"
-require_relative "abq/version"
+require "rspec/abq/extensions"
+require "rspec/abq/manifest"
+require "rspec/abq/ordering"
+require "rspec/abq/reporter"
+require "rspec/abq/test_case"
+require "rspec/abq/version"
 
 # We nest our patch into RSpec's module -- why not?
 module RSpec

--- a/spec/fixture_specs/failing_specs.rb
+++ b/spec/fixture_specs/failing_specs.rb
@@ -1,4 +1,4 @@
-require_relative "../spec_helper"
+require 'spec_helper'
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'a failing group' do

--- a/spec/fixture_specs/for_manifest/one_specs.rb
+++ b/spec/fixture_specs/for_manifest/one_specs.rb
@@ -1,4 +1,4 @@
-require_relative "../../spec_helper"
+require "spec_helper"
 
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs

--- a/spec/fixture_specs/for_manifest/two_specs.rb
+++ b/spec/fixture_specs/for_manifest/two_specs.rb
@@ -1,4 +1,4 @@
-require_relative "../../spec_helper"
+require "spec_helper"
 
 ## called `_specs.rb` to avoid it being called automatically
 # used by feature specs

--- a/spec/fixture_specs/pending_specs.rb
+++ b/spec/fixture_specs/pending_specs.rb
@@ -1,4 +1,4 @@
-require_relative "../spec_helper"
+require "spec_helper"
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'a pending group' do

--- a/spec/fixture_specs/raising_specs.rb
+++ b/spec/fixture_specs/raising_specs.rb
@@ -1,4 +1,4 @@
-require_relative "../spec_helper"
+require "spec_helper"
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'a raising group' do

--- a/spec/fixture_specs/specs_with_syntax_errors.rb
+++ b/spec/fixture_specs/specs_with_syntax_errors.rb
@@ -1,4 +1,4 @@
-require_relative "../spec_helper"
+require "spec_helper"
 # this file is named differently than all the other fixture_specs.rb so it doesn't get globbed with them
 # if it gets loaded, no specs run
 # used by feature specs

--- a/spec/fixture_specs/successful_specs.rb
+++ b/spec/fixture_specs/successful_specs.rb
@@ -1,4 +1,4 @@
-require_relative "../spec_helper"
+require "spec_helper"
 # called `_specs.rb` to avoid it being called automatically
 # used by feature specs
 RSpec.describe 'a successful group' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@ require "rspec/abq"
 require "rspec/snapshot"
 require "pry"
 
-require_relative "support/env_helper"
+require "support/env_helper"
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
   config.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
taking feedback from pairing from @dan-manges 

Fwiw: I prefer explicitness over implicitness, so I'm generally a fan of `require_relative` (for the same reason I'm not a plan of, e.g. `described_class` or `subject` or implicit, `it { is_supposed_to }`in specs ).

The occasional cost of having to move something around is IMO less than the benefit of the code being easier to read, the files in question being easier to find, etc.