### PR TITLE
Do not match on newline to find queue address

### DIFF
--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -10,7 +10,7 @@ module ABQQueue
       @q = {stdin_fd: stdin_fd, stdout_fd: stdout_fd, waiter: waiter}
       # read queue address
       data = ""
-      queue_regex = /(0.0.0.0:\d+)\n/
+      queue_regex = /(0.0.0.0:\d+)/
       data << stdout_fd.gets until data =~ queue_regex
       data.match(queue_regex)[1]
     end


### PR DESCRIPTION
This might have worked on older versions of abq but recent versions emit
only e.g.

```
Run the following to invoke a test run:
        abq test --queue-addr=0.0.0.0:63493 --run-id <a-unique-run-id> -- <your test args here>
Run the following to start one or more workers for that test run:
        abq work --queue-addr=0.0.0.0:63493 --run-id <the-same-run-id>
```

we could also be more sophisticated and pass a port we know is free, and
then healthcheck the queue until it is ready, but this works for now
(and is also what abq's integration tests do)
