### PR TITLE
fix documentation trigger

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,7 +3,8 @@ name: Deploy YARD documentation to Pages
 on:
   # Runs on pushes targeting the default branch
   push:
-    branches: [$default-branch]
+    branches:
+      - main
     paths:
       - '.github/workflows/pages.yml'
       - '.yardopts'


### PR DESCRIPTION
$default-branch is allowed for github actions & workflow templates but not for workflows. This fixes that