### PR TITLE
prepare release v1.0.7 and support new abq / captain integration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: .
   specs:
-    rspec-abq (1.0.6)
+    rspec-abq (1.0.7)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM
@@ -123,7 +123,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    sorbet-runtime (0.5.10634)
+    sorbet-runtime (0.5.10647)
     standard (1.22.1)
       language_server-protocol (~> 3.17.0.2)
       rubocop (= 1.42.0)

--- a/gemfiles/rspec-3.10.gemfile.lock
+++ b/gemfiles/rspec-3.10.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    rspec-abq (1.0.6)
+    rspec-abq (1.0.7)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM

--- a/gemfiles/rspec-3.11.gemfile.lock
+++ b/gemfiles/rspec-3.11.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    rspec-abq (1.0.6)
+    rspec-abq (1.0.7)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM

--- a/gemfiles/rspec-3.12.gemfile.lock
+++ b/gemfiles/rspec-3.12.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    rspec-abq (1.0.6)
+    rspec-abq (1.0.7)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM

--- a/gemfiles/rspec-3.5.gemfile.lock
+++ b/gemfiles/rspec-3.5.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    rspec-abq (1.0.6)
+    rspec-abq (1.0.7)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM

--- a/gemfiles/rspec-3.6.gemfile.lock
+++ b/gemfiles/rspec-3.6.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    rspec-abq (1.0.6)
+    rspec-abq (1.0.7)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM

--- a/gemfiles/rspec-3.7.gemfile.lock
+++ b/gemfiles/rspec-3.7.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    rspec-abq (1.0.6)
+    rspec-abq (1.0.7)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM

--- a/gemfiles/rspec-3.8.gemfile.lock
+++ b/gemfiles/rspec-3.8.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    rspec-abq (1.0.6)
+    rspec-abq (1.0.7)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM

--- a/gemfiles/rspec-3.9.gemfile.lock
+++ b/gemfiles/rspec-3.9.gemfile.lock
@@ -9,7 +9,7 @@ GIT
 PATH
   remote: ..
   specs:
-    rspec-abq (1.0.6)
+    rspec-abq (1.0.7)
       rspec-core (>= 3.5.0, < 3.13.0)
 
 GEM

--- a/lib/rspec/abq/version.rb
+++ b/lib/rspec/abq/version.rb
@@ -1,6 +1,6 @@
 module RSpec
   module Abq
     # current version!
-    VERSION = "1.0.6"
+    VERSION = "1.0.7"
   end
 end

--- a/spec/features/integration_spec.rb
+++ b/spec/features/integration_spec.rb
@@ -85,10 +85,11 @@ end
 
 RSpec.describe "abq test" do
   def abq_test(rspec_command, queue_address:, run_id:)
-    # RWX_ACCESS_TOKEN is set by `captain-cli`.
+    # RWX_ACCESS_TOKEN is used by `captain-cli` but is also interpreted by abq to connect to a remote queue
     # The tests uses a local queue.
-    # Here we unset RWX_ACCESS_TOKEN to prevent abq from trying to connect to a remote queue.
-    EnvHelper.with_env("RWX_ACCESS_TOKEN" => nil) do
+    # Unset RWX_ACCESS_TOKEN to prevent abq from trying to connect to a remote queue.
+    # captain-cli also sets ABQ_SET_EXIT_CODE and ABQ_STATE_FILE but we don't want our nested abq to be aware of them.
+    EnvHelper.with_env("RWX_ACCESS_TOKEN" => nil, "ABQ_SET_EXIT_CODE" => nil, "ABQ_STATE_FILE" => nil) do
       AbqTestRun.new(rspec_command, queue_address: queue_address, run_id: run_id).tap(&:run)
     end
   end

--- a/spec/features/test_result_spec.rb
+++ b/spec/features/test_result_spec.rb
@@ -1,5 +1,4 @@
 require "json"
-require "open3"
 require "spec_helper"
 
 RSpec.describe "test results", unless: RSpec::Abq.disable_tests_when_run_by_abq? do


### PR DESCRIPTION
initially was just releasing `rspec-abq` 1.0.7 but then I had to get CI green which involved unsetting some env vars set by `captain-cli`