### PR TITLE
Remove mentions from release template.

### DIFF
--- a/bin/release_gem.rb
+++ b/bin/release_gem.rb
@@ -117,9 +117,9 @@ RELEASE_TEMPLATE = <<~RELEASE_TEMPLATE
 
   # 🪙 Changelog 🪵
   ## Bugs
-  - fixed a cool bug [#123] (thanks @Janice !)
+  - fixed a cool bug [#000]
   ## Enhancements
-  - now we can do spacetravel[#1337] (cheers to @Bobak ! )
+  - now we can do spacetravel[#000]
 RELEASE_TEMPLATE
 
 Tempfile.create do |f|


### PR DESCRIPTION
The gem release script doesn't like something about my environment, and I may have mentioned someone last week. 🙀 I can work around it pretty easily, but in case anyone else hits this...