### PR TITLE
add abq metadata introduced in abq version 1.1.2

### DIFF
--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.10.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -75,6 +83,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -99,6 +111,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.11.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -75,6 +83,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -99,6 +111,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.12.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -75,6 +83,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -99,6 +111,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.5.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -75,6 +83,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -99,6 +111,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.6.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.6.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -75,6 +83,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -99,6 +111,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.7.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.7.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -75,6 +83,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -99,6 +111,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.8.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.8.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -75,6 +83,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -99,6 +111,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-passed-as-CLI-argument-test-results-rspec-3.9.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -75,6 +83,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -99,6 +111,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.10.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.11.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.12.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.5.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.6.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.6.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.7.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.7.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.8.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.8.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-ordering-set-in-rspec-config-test-results-rspec-3.9.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.10.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.11.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.12.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.5.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.6.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.6.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.7.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.7.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.8.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.8.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-random-seed-set-in-rspec-config-test-results-rspec-3.9.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -50,6 +54,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {

--- a/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.10.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.11.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.12.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.5.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.6.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.6.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.7.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.7.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.8.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.8.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-for-specs-together-with-a-hardcoded-seed-test-results-rspec-3.9.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.10.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.11.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.12.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.5.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.6.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.6.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.7.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.7.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.8.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.8.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-test-results-rspec-3.9.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -104,6 +112,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -143,6 +155,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -182,6 +198,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -221,6 +241,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -245,6 +269,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -270,6 +298,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -294,6 +326,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -318,6 +354,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -343,6 +383,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -367,6 +411,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -393,6 +441,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -418,6 +470,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -442,6 +498,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.10.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "screenshot": {
             "html": "tmp/screenshot.html",
             "image": "tmp/screenshot.png"
@@ -70,6 +74,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.11.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "screenshot": {
             "html": "tmp/screenshot.html",
             "image": "tmp/screenshot.png"
@@ -70,6 +74,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.12.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "screenshot": {
             "html": "tmp/screenshot.html",
             "image": "tmp/screenshot.png"
@@ -70,6 +74,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.5.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "screenshot": {
             "html": "tmp/screenshot.html",
             "image": "tmp/screenshot.png"
@@ -70,6 +74,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.6.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.6.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "screenshot": {
             "html": "tmp/screenshot.html",
             "image": "tmp/screenshot.png"
@@ -70,6 +74,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.7.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.7.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "screenshot": {
             "html": "tmp/screenshot.html",
             "image": "tmp/screenshot.png"
@@ -70,6 +74,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.8.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.8.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "screenshot": {
             "html": "tmp/screenshot.html",
             "image": "tmp/screenshot.png"
@@ -70,6 +74,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-&-capybara-inline-screenshot-test-results-rspec-3.9.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "screenshot": {
             "html": "tmp/screenshot.html",
             "image": "tmp/screenshot.png"
@@ -70,6 +74,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.10.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -66,6 +70,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.11.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -66,6 +70,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.12.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -66,6 +70,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.5.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -66,6 +70,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.6.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.6.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -66,6 +70,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.7.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.7.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -66,6 +70,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.8.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.8.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -66,6 +70,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-capybara-test-results-rspec-3.9.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -66,6 +70,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "type": "feature"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.10.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.10.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "\nexpected: true\n     got: false\n\n(compared using ==)\n\nDiff:\n@@ -1 +1 @@\n-true\n+false\n",
@@ -107,6 +115,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -120,6 +132,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "the roof",
@@ -162,6 +178,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -175,6 +195,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -214,6 +238,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -253,6 +281,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -281,6 +313,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -310,6 +346,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -338,6 +378,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -366,6 +410,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -391,6 +439,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -419,6 +471,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -445,6 +501,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -470,6 +530,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -494,6 +558,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.11.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.11.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "\nexpected: true\n     got: false\n\n(compared using ==)\n\nDiff:\n@@ -1 +1 @@\n-true\n+false\n",
@@ -107,6 +115,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -120,6 +132,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "the roof",
@@ -162,6 +178,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -175,6 +195,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -214,6 +238,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -253,6 +281,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -281,6 +313,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -310,6 +346,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -338,6 +378,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -366,6 +410,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -391,6 +439,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -419,6 +471,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -445,6 +501,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -470,6 +530,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -494,6 +558,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.12.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.12.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "\nexpected: true\n     got: false\n\n(compared using ==)\n\nDiff:\n@@ -1 +1 @@\n-true\n+false\n",
@@ -107,6 +115,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -120,6 +132,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "the roof",
@@ -162,6 +178,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -175,6 +195,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -214,6 +238,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -253,6 +281,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -281,6 +313,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -310,6 +346,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -338,6 +378,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -366,6 +410,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -391,6 +439,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -419,6 +471,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -445,6 +501,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -470,6 +530,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -494,6 +558,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.5.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.5.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "\nexpected: true\n     got: false\n\n(compared using ==)\n",
@@ -107,6 +115,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -120,6 +132,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "the roof",
@@ -162,6 +178,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -175,6 +195,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -214,6 +238,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -253,6 +281,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -281,6 +313,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -310,6 +346,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -338,6 +378,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -366,6 +410,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -391,6 +439,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -419,6 +471,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -445,6 +501,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -470,6 +530,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -494,6 +558,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.6.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.6.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "\nexpected: true\n     got: false\n\n(compared using ==)\n",
@@ -107,6 +115,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -120,6 +132,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "the roof",
@@ -162,6 +178,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -175,6 +195,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -214,6 +238,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -253,6 +281,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -281,6 +313,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -310,6 +346,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -338,6 +378,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -366,6 +410,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -391,6 +439,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -419,6 +471,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -445,6 +501,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -470,6 +530,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -494,6 +558,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.7.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.7.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "\nexpected: true\n     got: false\n\n(compared using ==)\n",
@@ -107,6 +115,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -120,6 +132,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "the roof",
@@ -162,6 +178,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -175,6 +195,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -214,6 +238,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -253,6 +281,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -281,6 +313,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -310,6 +346,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -338,6 +378,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -366,6 +410,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -391,6 +439,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -419,6 +471,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -445,6 +501,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -470,6 +530,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -494,6 +558,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.8.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.8.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "\nexpected: true\n     got: false\n\n(compared using ==)\n\nDiff:\n@@ -1 +1 @@\n-true\n+false\n",
@@ -107,6 +115,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -120,6 +132,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "the roof",
@@ -162,6 +178,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -175,6 +195,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -214,6 +238,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -253,6 +281,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -281,6 +313,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -310,6 +346,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -338,6 +378,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -366,6 +410,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -391,6 +439,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -419,6 +471,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -445,6 +501,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -470,6 +530,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -494,6 +558,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.9.gemfile.snap
+++ b/spec/features/__snapshots__/has-consistent-output-with-rspec-retry-test-results-rspec-3.9.gemfile.snap
@@ -26,6 +26,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -65,6 +69,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "\nexpected: true\n     got: false\n\n(compared using ==)\n\nDiff:\n@@ -1 +1 @@\n-true\n+false\n",
@@ -107,6 +115,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -120,6 +132,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 1,
           "retry_exceptions": [
             "the roof",
@@ -162,6 +178,10 @@
         {
           "durationInNanoseconds": 0,
           "meta": {
+            "abq_metadata": {
+              "runner": 1,
+              "worker": 0
+            }
           },
           "status": {
             "kind": "failed",
@@ -175,6 +195,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -214,6 +238,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -253,6 +281,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -281,6 +313,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -310,6 +346,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -338,6 +378,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -366,6 +410,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -391,6 +439,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "retry_attempts": 0,
           "retry_exceptions": [
 
@@ -419,6 +471,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xdescribe"
         },
         "startedAt": "2023-01-01T00:00:00Z",
@@ -445,6 +501,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -470,6 +530,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          }
         },
         "startedAt": "2023-01-01T00:00:00Z",
         "status": {
@@ -494,6 +558,10 @@
         "durationInNanoseconds": 234000,
         "finishedAt": "2023-01-01T00:00:00Z",
         "meta": {
+          "abq_metadata": {
+            "runner": 1,
+            "worker": 0
+          },
           "skip": "Temporarily skipped with xit"
         },
         "startedAt": "2023-01-01T00:00:00Z",

--- a/spec/rspec/abq_spec.rb
+++ b/spec/rspec/abq_spec.rb
@@ -148,6 +148,8 @@ RSpec.describe RSpec::Abq do
 
       it "fails with ConnectionFailed when connection times out", aggregate_failures: true do
         # Force this error to avoid flakiness.
+        expect(RSpec::Abq.instance_variable_get(:@socket)).to be_nil
+
         expect(Socket).to receive(:tcp).with(host, port.to_s, connect_timeout: 0.001)
           .and_raise(Errno::ETIMEDOUT, "forced error")
 

--- a/spec/rspec/abq_spec.rb
+++ b/spec/rspec/abq_spec.rb
@@ -6,6 +6,13 @@ def stringify_keys(hash)
 end
 
 RSpec.describe RSpec::Abq do
+  before do
+    # reset instance vars
+    RSpec::Abq.instance_variables.each do |instance_var|
+      RSpec::Abq.remove_instance_variable(instance_var)
+    end
+  end
+
   describe ".configure_rspec!", unless: RSpec::Abq.disable_tests_when_run_by_abq? do
     let(:init_message) { {init_meta: {seed: 124, ordering: "defined"}} }
     let(:configuration_double) do
@@ -30,9 +37,6 @@ RSpec.describe RSpec::Abq do
       # stub out socket communication
       allow(RSpec::Abq).to receive(:protocol_read).and_return(stringify_keys(init_message))
       allow(RSpec::Abq).to receive(:protocol_write)
-
-      RSpec::Abq.instance_variable_set(:@fast_exit, false)
-      RSpec::Abq.instance_variable_set(:@rspec_configured, false)
 
       # don't execute the ordering setup -- it's tested in integrations
       allow(RSpec::Abq::Ordering).to receive(:setup!)

--- a/spec/rspec/abq_spec.rb
+++ b/spec/rspec/abq_spec.rb
@@ -146,9 +146,9 @@ RSpec.describe RSpec::Abq do
         expect(RSpec::Abq.protocol_read(server_sock)).to(eq(stringify_keys(RSpec::Abq::NATIVE_RUNNER_SPAWNED_MESSAGE)))
       end
 
-      it "fails with ConnectionFailed when connection times out" do
+      it "fails with ConnectionFailed when connection times out", aggregate_failures: true do
         # Force this error to avoid flakiness.
-        allow(Socket).to receive(:tcp).with(host, port.to_s, connect_timeout: 0.001)
+        expect(Socket).to receive(:tcp).with(host, port.to_s, connect_timeout: 0.001)
           .and_raise(Errno::ETIMEDOUT, "forced error")
 
         expect do

--- a/spec/rspec/abq_spec.rb
+++ b/spec/rspec/abq_spec.rb
@@ -151,8 +151,6 @@ RSpec.describe RSpec::Abq do
 
       it "fails with ConnectionFailed when connection times out", aggregate_failures: true do
         # Force this error to avoid flakiness.
-        expect(RSpec::Abq.instance_variable_get(:@socket)).to be_nil
-
         expect(Socket).to receive(:tcp).with(host, port.to_s, connect_timeout: 0.001)
           .and_raise(Errno::ETIMEDOUT, "forced error")
 

--- a/spec/rspec/abq_spec.rb
+++ b/spec/rspec/abq_spec.rb
@@ -92,7 +92,10 @@ RSpec.describe RSpec::Abq do
       EnvHelper.with_env("ABQ_SOCKET" => "#{host}:#{port}") do
         example.call
       end
-      RSpec::Abq.instance_eval { @socket = nil }
+
+      RSpec::Abq.instance_variables.each do |instance_var|
+        RSpec::Abq.remove_instance_variable(instance_var)
+      end
     end
 
     describe ".protocol_write" do


### PR DESCRIPTION
snapshots changed because of env vars passed through in new abq version. This just updates the snapshots.