### PR TITLE
add tagged example

### DIFF
--- a/spec/fixture_specs/tagged_specs.rb
+++ b/spec/fixture_specs/tagged_specs.rb
@@ -1,0 +1,18 @@
+require "spec_helper"
+# called `_specs.rb` to avoid it being called automatically
+# used by feature specs
+RSpec.describe 'client-admin', client: :admin  do
+  10.times do |i|
+    it "admin test #{i}" do
+      expect(true).to eq(true)
+    end
+  end
+end
+
+RSpec.describe 'client-portal', client: :portal do
+  10.times do |i|
+    it "portal test #{i}" do
+      expect(true).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
run them as such:
```
abq test -- bundle exec rspec --pattern 'spec/fixture_specs/*_specs.rb' --tag client:admin
# or
abq test -- bundle exec rspec --pattern 'spec/fixture_specs/*_specs.rb' --tag client:portal
```

works for me with abq 1.3.0 😭 