### PR TITLE
Remove support for Ruby 2.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,18 +30,17 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 2.7
           - '3.0'
-          - 3.1
+          - '3.1'
         gemfile:
-          - 3.5
-          - 3.6
-          - 3.7
-          - 3.8
-          - 3.9
+          - '3.5'
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
           - '3.10'
-          - 3.11
-          - 3.12
+          - '3.11'
+          - '3.12'
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/rspec-${{ matrix.gemfile }}.gemfile
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,7 @@ inherit_gem:
   standard: config/base.yml
 
 AllCops:
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
   NewCops: enable
   Exclude:
     - 'bin/*' # don't worry about binstubs

--- a/rspec-abq.gemspec
+++ b/rspec-abq.gemspec
@@ -5,9 +5,10 @@ require_relative "lib/rspec/abq/version"
 Gem::Specification.new do |spec|
   spec.name = "rspec-abq"
   spec.version = RSpec::Abq::VERSION
-  spec.authors = ["Ayaz Hafiz", "Michael Glass"]
-  spec.email = ["ayaz@rwx.com", "me@rwx.com"]
+  spec.authors = ["rwx", "Ayaz Hafiz", "Michael Glass"]
+  spec.email = ["support@rwx.com"]
   spec.license = "MIT"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.summary = "RSpec::Abq allows for parallel rspec runs using abq"
   spec.description = "RSpec::Abq is an rspec plugin that replaces its ordering with one that is controlled by abq. It allows for parallelization of rspec on a single machine or across multiple workers."


### PR DESCRIPTION
While working on updating development gems in #117 I noticed that some of our dependencies have started requiring ruby `>= 3`. Ruby 2.7 was EOL on 31 Mar 2023, so we're going to drop support for it.